### PR TITLE
drivers: gpio: Add basic GPIO driver api and STM32F407G implementation

### DIFF
--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -1,3 +1,5 @@
 include("${PROJECT_SOURCE_DIR}/toolchains/compiler-flags.cmake")
 add_library(testd test-driver.c)
 target_include_directories(testd PUBLIC  "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/src/drivers/include")
+add_library(gpio gpio.c)
+target_include_directories(gpio PUBLIC  "${PROJECT_BINARY_DIR}" "${PROJECT_SOURCE_DIR}/src/drivers/include" "${PROJECT_SOURCE_DIR}/src/platform/stm32f407G/include")

--- a/src/drivers/gpio.c
+++ b/src/drivers/gpio.c
@@ -1,0 +1,101 @@
+#include "include/gpio.h"
+#include "platform_defs.h"
+#include <stdint.h>
+
+static const uint32_t port_list[] = {
+	GPIOA_BASE,
+	GPIOB_BASE,
+	GPIOC_BASE,
+	GPIOD_BASE,
+	GPIOE_BASE,
+	GPIOF_BASE,
+	GPIOG_BASE,
+	GPIOH_BASE,
+	GPIOI_BASE,
+	GPIOJ_BASE,
+	GPIOK_BASE
+};
+
+static int gpio_apply_config(struct gpio *gpio)
+{
+	uint32_t port_addr = port_list[gpio->data.port];
+	/* set mode */
+	clear_bits(port_addr + GPIO_MODER, 0x3 << (gpio->data.pin*2));
+	set_bits(port_addr + GPIO_MODER, gpio->data.mode << (gpio->data.pin*2));
+	if (gpio->data.mode == OUTPUT) {
+		clear_bits(port_addr + GPIO_OTYPER, (1 << gpio->data.pin));
+		set_bits(port_addr + GPIO_OTYPER, gpio->data.otype << gpio->data.pin);
+	} else if (gpio->data.mode == INPUT) {
+		clear_bits(port_addr + GPIO_PUPDR, 0x3 << (gpio->data.pin*2));
+		set_bits(port_addr + GPIO_PUPDR, gpio->data.ptype << (gpio->data.pin*2));
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+static int gpio_configure(struct gpio *gpio, enum gpio_mode mode,
+			  enum gpio_otype otype, enum gpio_ptype ptype)
+{
+	if (mode == INPUT && otype != NOT_OUT)
+		return -EINVAL;
+	if (mode == OUTPUT && ptype != NOT_IN)
+		return -EINVAL;
+	gpio->data.mode = mode;
+	gpio->data.otype = otype;
+	gpio->data.ptype = ptype;
+	gpio_apply_config(gpio);
+	return 0;
+}
+
+static int gpio_write_val(struct gpio *gpio, enum gpio_state val)
+{
+	uint32_t port_addr = port_list[gpio->data.port];
+
+	if (gpio->data.mode != OUTPUT)
+		return -ENOTSUP;
+
+	if (val)
+		set_bits(port_addr + GPIO_ODR, 1 << gpio->data.pin);
+	else
+		clear_bits(port_addr + GPIO_ODR, 1 << gpio->data.pin);
+
+	return 0;
+}
+
+static int gpio_read_val(struct gpio *gpio)
+{
+	uint32_t port_addr = port_list[gpio->data.port];
+
+	if (gpio->data.mode != INPUT)
+		return -ENOTSUP;
+
+	return read_reg(port_addr + GPIO_IDR) & (1 << gpio->data.pin);
+}
+
+static const struct gpio_ops gpio_operations = {
+	.configure = gpio_configure,
+	.read_val = gpio_read_val,
+	.write_val = gpio_write_val
+};
+
+/* use to init gpio and prefill gpio struct */
+struct gpio gpio_create(uint32_t port, uint32_t pin)
+{
+	struct gpio gpio_dev;
+
+	gpio_dev.data.port = port;
+	gpio_dev.data.pin = pin;
+	gpio_dev.ops = &gpio_operations;
+
+	return gpio_dev;
+};
+
+int gpio_periph_init(void *data)
+{
+	/* enable all gpio */
+	write_reg(RCC_AHB1ENR, (0xff));
+
+	return 0;
+}

--- a/src/drivers/include/gpio.h
+++ b/src/drivers/include/gpio.h
@@ -1,0 +1,60 @@
+#ifndef GPIO_H
+#define GPIO_H
+
+#include <stdint.h>
+
+/* implement if device needs additional preparation */
+int gpio_periph_init(void *data);
+
+enum gpio_mode {
+	INPUT,
+	OUTPUT,
+	ALTERNATE,
+	ANALOG
+};
+
+/* Output type */
+enum gpio_otype {
+	PUSH_PULL,
+	OPEN_DRAIN,
+	NOT_OUT
+};
+
+/* Pull type */
+enum gpio_ptype {
+	NO_PULL,
+	PULLUP,
+	PULLDOWN,
+	NOT_IN
+};
+
+enum gpio_state {
+	LOW,
+	HIGH
+};
+
+/* use to init gpio and prefill gpio struct */
+struct gpio gpio_create(uint32_t port, uint32_t pin);
+
+/* gpio operations */
+struct gpio_ops {
+	int (*configure)(struct gpio *gpio, enum gpio_mode mode,
+			 enum gpio_otype otype, enum gpio_ptype ptype);
+	int (*write_val)(struct gpio *gpio, enum gpio_state val);
+	int (*read_val)(struct gpio *gpio);
+};
+
+struct gpio_data {
+	uint32_t port;
+	uint32_t pin;
+	enum gpio_mode mode;
+	enum gpio_otype otype;
+	enum gpio_ptype ptype;
+};
+
+struct gpio {
+	struct gpio_data data;
+	struct gpio_ops *ops;
+};
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,17 +1,30 @@
-#include "test-driver.h"
-#include "test-lib.h"
+#include <stddef.h>
 #include "platform/stm32f407G/include/platform_init.h"
+#include "gpio.h"
+
+#define BUTT_PORT 0
+#define BUTT_PIN 0
 
 int main()
 {
+	int pressed = 0;
+
 	platform_init();
+	gpio_periph_init(NULL);
 
-	int result = 0;
+	struct gpio BUT = gpio_create(BUTT_PORT, BUTT_PIN);
+	struct gpio LED = gpio_create(3, 13);
 
-	result = testlib(result);
-	result = testdriver(result);
+	BUT.ops->configure(&BUT, INPUT, NOT_OUT, PULLDOWN);
+	LED.ops->configure(&LED, OUTPUT, PUSH_PULL, NOT_IN);
 
-	while(1){}
+	while (1) {
+		pressed = BUT.ops->read_val(&BUT);
+		if (pressed)
+			LED.ops->write_val(&LED, HIGH);
+		else
+			LED.ops->write_val(&LED, LOW);
+	}
 	
 	return 0;
 }

--- a/src/platform/stm32f407G/CMakeLists.txt
+++ b/src/platform/stm32f407G/CMakeLists.txt
@@ -1,2 +1,2 @@
 set(LIBRARIES testl)
-set(DRIVERS testd)
+set(DRIVERS testd gpio)

--- a/src/platform/stm32f407G/include/platform_defs.h
+++ b/src/platform/stm32f407G/include/platform_defs.h
@@ -13,6 +13,16 @@ static inline void write_reg(uint32_t addr, uint32_t val)
 	*(uint32_t *) addr = val;
 }
 
+static inline void set_bits(uint32_t addr, uint32_t val)
+{
+	write_reg(addr, read_reg(addr) | val);
+}
+
+static inline void clear_bits(uint32_t addr, uint32_t val)
+{
+	write_reg(addr, read_reg(addr) & ~val);
+}
+
 /* clock defines */
 #define RCC_BASE 0x40023800
 #define RCC_CR (RCC_BASE + 0x00)
@@ -22,5 +32,38 @@ static inline void write_reg(uint32_t addr, uint32_t val)
 /* flash defines */
 #define FLASH_IFACE_BASE 0x40023C00
 #define FLASH_ACR (FLASH_IFACE_BASE + 0x00)
+
+/* GPIO defines */
+#define GPIO_BASE 0x40020000
+#define GPIOA_BASE (GPIO_BASE + 0x0000)
+#define GPIOB_BASE (GPIO_BASE + 0x0400)
+#define GPIOC_BASE (GPIO_BASE + 0x0800)
+#define GPIOD_BASE (GPIO_BASE + 0x0C00)
+#define GPIOE_BASE (GPIO_BASE + 0x1000)
+#define GPIOF_BASE (GPIO_BASE + 0x1400)
+#define GPIOG_BASE (GPIO_BASE + 0x1800)
+#define GPIOH_BASE (GPIO_BASE + 0x1C00)
+#define GPIOI_BASE (GPIO_BASE + 0x2000)
+#define GPIOJ_BASE (GPIO_BASE + 0x2400)
+#define GPIOK_BASE (GPIO_BASE + 0x2800)
+
+#define GPIO_MODER 0x00
+#define GPIO_OTYPER 0x04
+#define GPIO_OSPEEDR 0x08
+#define GPIO_PUPDR 0x0C
+#define GPIO_IDR 0x10
+#define GPIO_ODR 0x14
+#define GPIO_BSRR 0x18
+#define GPIO_LCKR 0x1C
+#define GPIO_AFRL 0x20
+#define GPIO_AFRH 0x24
+
+#define RCC_AHB1ENR (RCC_BASE + 0x30)
+
+
+/* ERROR CODES */
+#define ENOTSUP 134
+#define EINVAL 22
+/* TODO: move out of platform specific */
 
 #endif


### PR DESCRIPTION
Api allows to drive single IO pin. Initialization, Read//write operations are supported. Supports multiple pin modes - push/pull, pullups. No support for additional functions yet. No support for GPIO interrupts yet.