### PR TITLE
UT: Add ceedling UT setup and workflow to PRs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,28 @@
+name: Unit Tests
+run-name: Unit Tests ${{ github.run_number }}
+on:
+  pull_request:
+    branches:
+    - main
+jobs:
+  Run-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Install prerequisites
+        run: >
+          sudo apt-get install ruby && sudo apt-get install gcovr && sudo gem install ceedling
+      - name: Run unit tests
+        run: ceedling test:all
+        shell: bash
+      - name: Generate results
+        run: >
+          ceedling gcov:all &> /dev/null;
+          ceedling utils:gcov || ls
+      - name: Archive UT results
+        uses: actions/upload-artifact@v3
+        with:
+          name: code-coverage-report
+          path: bin/UT/artifacts/gcov
+          retention-days: 7

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,109 @@
+---
+
+# Notes:
+# Sample project C code is not presently written to produce a release artifact.
+# As such, release build options are disabled.
+# This sample, therefore, only demonstrates running a collection of unit tests.
+
+:project:
+  :use_exceptions: FALSE
+  :use_test_preprocessor: TRUE
+  :use_auxiliary_dependencies: TRUE
+  :build_root: bin/UT
+#  :release_build: TRUE
+  :test_file_prefix: test_
+  :which_ceedling: gem
+  :ceedling_version: 0.31.1
+  :default_tasks:
+    - test:all
+
+#:test_build:
+#  :use_assembly: TRUE
+
+#:release_build:
+#  :output: MyApp.out
+#  :use_assembly: FALSE
+
+:environment:
+
+:extension:
+  :executable: .out
+
+:paths:
+  :test:
+    - +:test/**
+    - -:test/support
+  :source:
+    - src/**
+  :support:
+    - test/support
+  :libraries: []
+
+:module_generator:
+  :source_root: src/lib/
+  :inc_root: src/lib/include/
+
+:defines:
+  # in order to add common defines:
+  #  1) remove the trailing [] from the :common: section
+  #  2) add entries to the :common: section (e.g. :test: has TEST defined)
+  :common: &common_defines []
+  :test:
+    - *common_defines
+    - TEST
+  :test_preprocess:
+    - *common_defines
+    - TEST
+
+:cmock:
+  :mock_prefix: mock_
+  :when_no_prototypes: :warn
+  :enforce_strict_ordering: TRUE
+  :plugins:
+    - :ignore
+    - :callback
+  :treat_as:
+    uint8:    HEX8
+    uint16:   HEX16
+    uint32:   UINT32
+    int8:     INT8
+    bool:     UINT8
+
+# Add -gcov to the plugins list to make sure of the gcov plugin
+# You will need to have gcov and gcovr both installed to make it work.
+# For more information on these options, see docs in plugins/gcov
+:gcov:
+  :reports:
+    - HtmlDetailed
+  :gcovr:
+    :html_medium_threshold: 75
+    :html_high_threshold: 90
+
+#:tools:
+# Ceedling defaults to using gcc for compiling, linking, etc.
+# As [:tools] is blank, gcc will be used (so long as it's in your system path)
+# See documentation to configure a given toolchain for use
+
+# LIBRARIES
+# These libraries are automatically injected into the build process. Those specified as
+# common will be used in all types of builds. Otherwise, libraries can be injected in just
+# tests or releases. These options are MERGED with the options in supplemental yaml files.
+:libraries:
+  :placement: :end
+  :flag: "-l${1}"
+  :path_flag: "-L ${1}"
+  :system: []    # for example, you might list 'm' to grab the math library
+  :test: []
+  :release: []
+
+# Must use stdout_pretty_tests_report for CI purposes
+# Feel fr to use - stdout_gtestlike_tests_report during development
+# Return value depends on output mechanism. Issue open in ceedling gh.
+:plugins:
+  :load_paths:
+    - "#{Ceedling.load_path}"
+  :enabled:
+    - module_generator
+    - gcov
+    - stdout_pretty_tests_report
+...


### PR DESCRIPTION
Use ceedling and unity to perform unit testis on x86 arch.

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>