### PR TITLE
platform: errors: use errno.h instead of defined errors.

### DIFF
--- a/src/drivers/gpio.c
+++ b/src/drivers/gpio.c
@@ -1,5 +1,6 @@
 #include "include/gpio.h"
 #include "platform_defs.h"
+#include "errno.h"
 #include <stdint.h>
 
 static const uint32_t port_list[] = {

--- a/src/platform/stm32f407G/include/platform_defs.h
+++ b/src/platform/stm32f407G/include/platform_defs.h
@@ -61,9 +61,4 @@ static inline void clear_bits(uint32_t addr, uint32_t val)
 #define RCC_AHB1ENR (RCC_BASE + 0x30)
 
 
-/* ERROR CODES */
-#define ENOTSUP 134
-#define EINVAL 22
-/* TODO: move out of platform specific */
-
 #endif


### PR DESCRIPTION
No need to implement own error codes. Use posix codes from errno.h

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>