### PR TITLE
workflows: UT: Show output of raport generation

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,8 +18,8 @@ jobs:
         shell: bash
       - name: Generate results
         run: >
-          ceedling gcov:all &> /dev/null;
-          ceedling utils:gcov || ls
+          ceedling gcov:all;
+          ceedling utils:gcov
       - name: Archive UT results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Despite showing some errorous messages it is helpful when looking for errors and shows coverage.

Signed-off-by: root <frydryk.krzysztof@gmail.com>