### PR TITLE
lib: thresholds: Add initial thresholds impementation

### DIFF
--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -7,3 +7,6 @@ target_include_directories(testl PUBLIC  ${INCLUDE_DIRS})
 
 add_library(linked-list linked-list.c)
 target_include_directories(linked-list PUBLIC  ${INCLUDE_DIRS})
+
+add_library(thresholds thresholds.c)
+target_include_directories(thresholds PUBLIC  ${INCLUDE_DIRS})

--- a/src/lib/include/thresholds.h
+++ b/src/lib/include/thresholds.h
@@ -1,0 +1,16 @@
+#ifndef STATE_MACHINE_H
+#define STATE_MACHINE_H
+
+#include "linked-list.h"
+#include <stdint.h>
+#include <stdbool.h>
+
+struct threshold {
+	struct linked_list *lli;
+	uint32_t val;
+};
+
+int threshold_next(struct threshold *thr);
+int threshold_init(struct threshold *thr, struct linked_list *lli);
+
+#endif

--- a/src/lib/thresholds.c
+++ b/src/lib/thresholds.c
@@ -1,0 +1,25 @@
+#include "include/thresholds.h"
+#include <errno.h>
+#include <stddef.h>
+
+int threshold_next(struct threshold *thr)
+{
+	if (thr->lli == NULL)
+		return -EINVAL;
+
+	thr->lli = thr->lli->next;
+	thr->val = *(uint32_t *)thr->lli->data;
+
+	return 0;
+}
+
+int threshold_init(struct threshold *thr, struct linked_list *lli)
+{
+	if ((thr == NULL) || (lli == NULL))
+		return -EINVAL;
+
+	thr->lli = lli;
+	thr->val = *(uint32_t *)lli->data;
+
+	return 0;
+}

--- a/src/platform/stm32f407G/CMakeLists.txt
+++ b/src/platform/stm32f407G/CMakeLists.txt
@@ -1,2 +1,2 @@
-set(LIBRARIES testl linked-list)
+set(LIBRARIES testl linked-list thresholds)
 set(DRIVERS testd gpio)

--- a/test/test_thresholds.c
+++ b/test/test_thresholds.c
@@ -1,0 +1,114 @@
+#ifdef TEST
+
+#include "unity.h"
+
+#include "thresholds.h"
+#include "linked-list.h"
+
+uint32_t data;
+uint32_t data2;
+
+void setUp(void)
+{
+}
+
+void tearDown(void)
+{
+}
+
+void test_thresholds_init(void)
+{
+	int ret;
+	struct threshold thr;
+	struct linked_list lli;
+
+	ret = linked_list_init(&lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	lli.data = &data;
+
+	ret = threshold_init(&thr, &lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(thr.lli, &lli);
+	TEST_ASSERT_EQUAL(thr.val, *(uint32_t *)lli.data);
+}
+
+void test_thresholds_init_null_lli(void)
+{
+	int ret;
+	struct threshold thr;
+
+	ret = threshold_init(&thr, NULL);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
+void test_thresholds_init_null_thr(void)
+{
+	int ret;
+	struct linked_list lli;
+
+	ret = linked_list_init(&lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	lli.data = &data;
+
+	ret = threshold_init(NULL, &lli);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
+void test_thresholds_next(void)
+{
+	int ret;
+	struct threshold thr;
+	struct linked_list lli;
+	struct linked_list lli2;
+
+	ret = linked_list_init(&lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	lli.data = &data;
+
+	ret = linked_list_append(&lli, &lli2);
+	TEST_ASSERT_EQUAL(0, ret);
+	lli2.data = &data2;
+
+	ret = threshold_init(&thr, &lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(thr.lli, &lli);
+	TEST_ASSERT_EQUAL(thr.val, *(uint32_t *)lli.data);
+
+	ret = threshold_next(&thr);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(thr.lli, &lli2);
+	TEST_ASSERT_EQUAL(thr.val, *(uint32_t *)lli2.data);
+}
+
+void test_thresholds_next_null_lli(void)
+{
+	/* prepare */
+	int ret;
+	struct threshold thr;
+	struct linked_list lli;
+	struct linked_list lli2;
+
+	ret = linked_list_init(&lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	lli.data = &data;
+
+	ret = linked_list_append(&lli, &lli2);
+	TEST_ASSERT_EQUAL(0, ret);
+	lli2.data = &data2;
+
+	ret = threshold_init(&thr, &lli);
+	TEST_ASSERT_EQUAL(0, ret);
+	TEST_ASSERT_EQUAL(thr.lli, &lli);
+	TEST_ASSERT_EQUAL(thr.val, *(uint32_t *)lli.data);
+
+	thr.lli = NULL;
+
+	/* test */
+	ret = threshold_next(&thr);
+	TEST_ASSERT_NOT_EQUAL(0, ret);
+}
+
+
+
+
+#endif // TEST


### PR DESCRIPTION
Add initial thresholds implementation.
Threshold struct contains current threshold value and linked list to iterate over values in circular maner.

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>