### PR TITLE
drivers: gpio: add funtcion to configure gpio as interrupt source.

### DIFF
--- a/src/drivers/include/gpio.h
+++ b/src/drivers/include/gpio.h
@@ -33,8 +33,29 @@ enum gpio_state {
 	HIGH
 };
 
+enum gpio_int_event {
+	FALLING_EDGE,
+	RISING_EDGE
+};
+
+enum gpio_port {
+	PA,
+	PB,
+	PC,
+	PD,
+	PE,
+	PF,
+	PG,
+	PH,
+	PI
+};
+
 /* use to init gpio and prefill gpio struct */
 struct gpio gpio_create(uint32_t port, uint32_t pin);
+int gpio_configure_output(struct gpio *gpio, enum gpio_otype otype);
+int gpio_configure_input(struct gpio *gpio, enum gpio_ptype ptype);
+/* NOTE: IRQ handler has to be defined separately! */
+int gpio_configure_interrupt(struct gpio *gpio, enum gpio_int_event event);
 
 /* gpio operations */
 struct gpio_ops {

--- a/src/platform/stm32f407G/include/platform_defs.h
+++ b/src/platform/stm32f407G/include/platform_defs.h
@@ -28,6 +28,27 @@ static inline void clear_bits(uint32_t addr, uint32_t val)
 #define RCC_CR (RCC_BASE + 0x00)
 #define RCC_PLLCFGR (RCC_BASE + 0x04)
 #define RCC_CFGR (RCC_BASE + 0x08)
+#define RCC_APB2ENR (RCC_BASE + 0x44)
+#define RCC_AHB1ENR (RCC_BASE + 0x30)
+
+/* RCC_APB2ENR defines */
+#define SYSCFGEN (1 << 14)
+
+/* syscfg defines */
+#define SYSCFG_BASE 0x40013800
+#define SYSCFG_EXTICR(x) SYSCFG_EXTICR ## x
+#define SYSCFG_EXTICR1 (SYSCFG_BASE + 0x08)
+#define SYSCFG_EXTICR2 (SYSCFG_BASE + 0x0C)
+#define SYSCFG_EXTICR3 (SYSCFG_BASE + 0x10)
+#define SYSCFG_EXTICR4 (SYSCFG_BASE + 0x14)
+
+
+/* exti defines */
+#define EXTI_BASE 0x40013C00
+#define EXTI_IMR (EXTI_BASE + 0x00)
+#define EXTI_RTSR (EXTI_BASE + 0x08)
+#define EXTI_FTSR (EXTI_BASE + 0x0C)
+#define EXTI_PR (EXTI_BASE + 0x14)
 
 /* flash defines */
 #define FLASH_IFACE_BASE 0x40023C00
@@ -58,7 +79,136 @@ static inline void clear_bits(uint32_t addr, uint32_t val)
 #define GPIO_AFRL 0x20
 #define GPIO_AFRH 0x24
 
-#define RCC_AHB1ENR (RCC_BASE + 0x30)
+/* irqs */
+/* from ARMv7-M_ARM datasheet */
+#define NVIC_BASE 0xE000E100
+/* am not defining all of those just for consistency */
+struct NVIC
+{
+	volatile uint32_t ISER[8U];
+	uint32_t rsv0[24U];
+	volatile uint32_t ICER[8U];
+	uint32_t rsv1[24U];
+	volatile uint32_t ISPR[8U];
+	uint32_t rsv2[24U];
+	volatile uint32_t ICPR[8U];
+	uint32_t rsv3[24U];
+	volatile uint32_t IABR[8U];
+	uint32_t rsv4[56U];
+	volatile uint8_t  IP[240U];
+	uint32_t rsv5[644U];
+	volatile  uint32_t STIR;
+};
+#define NVIC ((struct NVIC *) NVIC_BASE)
+
+static inline void irq_enable(uint32_t irq_n)
+{
+	NVIC->ISER[irq_n / 32] = (0x01 << (irq_n % 32));
+}
+
+static inline void irq_set_priority(uint32_t irq_n, uint32_t prio)
+{
+	/* use only 8 priority levels */
+	NVIC->IP[irq_n] = (prio << 5) % 255;
+}
+
+
+/* copied shamelesly from CMSIS header, not gonna retype this myself. */
+enum IRQn
+{
+/******  Cortex-M4 Processor Exceptions Numbers ****************************************************************/
+  NonMaskableInt_IRQn         = -14,    /*!< 2 Non Maskable Interrupt                                          */
+  MemoryManagement_IRQn       = -12,    /*!< 4 Cortex-M4 Memory Management Interrupt                           */
+  BusFault_IRQn               = -11,    /*!< 5 Cortex-M4 Bus Fault Interrupt                                   */
+  UsageFault_IRQn             = -10,    /*!< 6 Cortex-M4 Usage Fault Interrupt                                 */
+  SVCall_IRQn                 = -5,     /*!< 11 Cortex-M4 SV Call Interrupt                                    */
+  DebugMonitor_IRQn           = -4,     /*!< 12 Cortex-M4 Debug Monitor Interrupt                              */
+  PendSV_IRQn                 = -2,     /*!< 14 Cortex-M4 Pend SV Interrupt                                    */
+  SysTick_IRQn                = -1,     /*!< 15 Cortex-M4 System Tick Interrupt                                */
+/******  STM32 specific Interrupt Numbers **********************************************************************/
+  WWDG_IRQn                   = 0,      /*!< Window WatchDog Interrupt                                         */
+  PVD_IRQn                    = 1,      /*!< PVD through EXTI Line detection Interrupt                         */
+  TAMP_STAMP_IRQn             = 2,      /*!< Tamper and TimeStamp interrupts through the EXTI line             */
+  RTC_WKUP_IRQn               = 3,      /*!< RTC Wakeup interrupt through the EXTI line                        */
+  FLASH_IRQn                  = 4,      /*!< FLASH global Interrupt                                            */
+  RCC_IRQn                    = 5,      /*!< RCC global Interrupt                                              */
+  EXTI0_IRQn                  = 6,      /*!< EXTI Line0 Interrupt                                              */
+  EXTI1_IRQn                  = 7,      /*!< EXTI Line1 Interrupt                                              */
+  EXTI2_IRQn                  = 8,      /*!< EXTI Line2 Interrupt                                              */
+  EXTI3_IRQn                  = 9,      /*!< EXTI Line3 Interrupt                                              */
+  EXTI4_IRQn                  = 10,     /*!< EXTI Line4 Interrupt                                              */
+  DMA1_Stream0_IRQn           = 11,     /*!< DMA1 Stream 0 global Interrupt                                    */
+  DMA1_Stream1_IRQn           = 12,     /*!< DMA1 Stream 1 global Interrupt                                    */
+  DMA1_Stream2_IRQn           = 13,     /*!< DMA1 Stream 2 global Interrupt                                    */
+  DMA1_Stream3_IRQn           = 14,     /*!< DMA1 Stream 3 global Interrupt                                    */
+  DMA1_Stream4_IRQn           = 15,     /*!< DMA1 Stream 4 global Interrupt                                    */
+  DMA1_Stream5_IRQn           = 16,     /*!< DMA1 Stream 5 global Interrupt                                    */
+  DMA1_Stream6_IRQn           = 17,     /*!< DMA1 Stream 6 global Interrupt                                    */
+  ADC_IRQn                    = 18,     /*!< ADC1, ADC2 and ADC3 global Interrupts                             */
+  CAN1_TX_IRQn                = 19,     /*!< CAN1 TX Interrupt                                                 */
+  CAN1_RX0_IRQn               = 20,     /*!< CAN1 RX0 Interrupt                                                */
+  CAN1_RX1_IRQn               = 21,     /*!< CAN1 RX1 Interrupt                                                */
+  CAN1_SCE_IRQn               = 22,     /*!< CAN1 SCE Interrupt                                                */
+  EXTI9_5_IRQn                = 23,     /*!< External Line[9:5] Interrupts                                     */
+  TIM1_BRK_TIM9_IRQn          = 24,     /*!< TIM1 Break interrupt and TIM9 global interrupt                    */
+  TIM1_UP_TIM10_IRQn          = 25,     /*!< TIM1 Update Interrupt and TIM10 global interrupt                  */
+  TIM1_TRG_COM_TIM11_IRQn     = 26,     /*!< TIM1 Trigger and Commutation Interrupt and TIM11 global interrupt */
+  TIM1_CC_IRQn                = 27,     /*!< TIM1 Capture Compare Interrupt                                    */
+  TIM2_IRQn                   = 28,     /*!< TIM2 global Interrupt                                             */
+  TIM3_IRQn                   = 29,     /*!< TIM3 global Interrupt                                             */
+  TIM4_IRQn                   = 30,     /*!< TIM4 global Interrupt                                             */
+  I2C1_EV_IRQn                = 31,     /*!< I2C1 Event Interrupt                                              */
+  I2C1_ER_IRQn                = 32,     /*!< I2C1 Error Interrupt                                              */
+  I2C2_EV_IRQn                = 33,     /*!< I2C2 Event Interrupt                                              */
+  I2C2_ER_IRQn                = 34,     /*!< I2C2 Error Interrupt                                              */
+  SPI1_IRQn                   = 35,     /*!< SPI1 global Interrupt                                             */
+  SPI2_IRQn                   = 36,     /*!< SPI2 global Interrupt                                             */
+  USART1_IRQn                 = 37,     /*!< USART1 global Interrupt                                           */
+  USART2_IRQn                 = 38,     /*!< USART2 global Interrupt                                           */
+  USART3_IRQn                 = 39,     /*!< USART3 global Interrupt                                           */
+  EXTI15_10_IRQn              = 40,     /*!< External Line[15:10] Interrupts                                   */
+  RTC_Alarm_IRQn              = 41,     /*!< RTC Alarm (A and B) through EXTI Line Interrupt                   */
+  OTG_FS_WKUP_IRQn            = 42,     /*!< USB OTG FS Wakeup through EXTI line interrupt                     */
+  TIM8_BRK_TIM12_IRQn         = 43,     /*!< TIM8 Break Interrupt and TIM12 global interrupt                   */
+  TIM8_UP_TIM13_IRQn          = 44,     /*!< TIM8 Update Interrupt and TIM13 global interrupt                  */
+  TIM8_TRG_COM_TIM14_IRQn     = 45,     /*!< TIM8 Trigger and Commutation Interrupt and TIM14 global interrupt */
+  TIM8_CC_IRQn                = 46,     /*!< TIM8 Capture Compare Interrupt                                    */
+  DMA1_Stream7_IRQn           = 47,     /*!< DMA1 Stream7 Interrupt                                            */
+  FSMC_IRQn                   = 48,     /*!< FSMC global Interrupt                                             */
+  SDIO_IRQn                   = 49,     /*!< SDIO global Interrupt                                             */
+  TIM5_IRQn                   = 50,     /*!< TIM5 global Interrupt                                             */
+  SPI3_IRQn                   = 51,     /*!< SPI3 global Interrupt                                             */
+  UART4_IRQn                  = 52,     /*!< UART4 global Interrupt                                            */
+  UART5_IRQn                  = 53,     /*!< UART5 global Interrupt                                            */
+  TIM6_DAC_IRQn               = 54,     /*!< TIM6 global and DAC1&2 underrun error  interrupts                 */
+  TIM7_IRQn                   = 55,     /*!< TIM7 global interrupt                                             */
+  DMA2_Stream0_IRQn           = 56,     /*!< DMA2 Stream 0 global Interrupt                                    */
+  DMA2_Stream1_IRQn           = 57,     /*!< DMA2 Stream 1 global Interrupt                                    */
+  DMA2_Stream2_IRQn           = 58,     /*!< DMA2 Stream 2 global Interrupt                                    */
+  DMA2_Stream3_IRQn           = 59,     /*!< DMA2 Stream 3 global Interrupt                                    */
+  DMA2_Stream4_IRQn           = 60,     /*!< DMA2 Stream 4 global Interrupt                                    */
+  ETH_IRQn                    = 61,     /*!< Ethernet global Interrupt                                         */
+  ETH_WKUP_IRQn               = 62,     /*!< Ethernet Wakeup through EXTI line Interrupt                       */
+  CAN2_TX_IRQn                = 63,     /*!< CAN2 TX Interrupt                                                 */
+  CAN2_RX0_IRQn               = 64,     /*!< CAN2 RX0 Interrupt                                                */
+  CAN2_RX1_IRQn               = 65,     /*!< CAN2 RX1 Interrupt                                                */
+  CAN2_SCE_IRQn               = 66,     /*!< CAN2 SCE Interrupt                                                */
+  OTG_FS_IRQn                 = 67,     /*!< USB OTG FS global Interrupt                                       */
+  DMA2_Stream5_IRQn           = 68,     /*!< DMA2 Stream 5 global interrupt                                    */
+  DMA2_Stream6_IRQn           = 69,     /*!< DMA2 Stream 6 global interrupt                                    */
+  DMA2_Stream7_IRQn           = 70,     /*!< DMA2 Stream 7 global interrupt                                    */
+  USART6_IRQn                 = 71,     /*!< USART6 global interrupt                                           */
+  I2C3_EV_IRQn                = 72,     /*!< I2C3 event interrupt                                              */
+  I2C3_ER_IRQn                = 73,     /*!< I2C3 error interrupt                                              */
+  OTG_HS_EP1_OUT_IRQn         = 74,     /*!< USB OTG HS End Point 1 Out global interrupt                       */
+  OTG_HS_EP1_IN_IRQn          = 75,     /*!< USB OTG HS End Point 1 In global interrupt                        */
+  OTG_HS_WKUP_IRQn            = 76,     /*!< USB OTG HS Wakeup through EXTI interrupt                          */
+  OTG_HS_IRQn                 = 77,     /*!< USB OTG HS global interrupt                                       */
+  DCMI_IRQn                   = 78,     /*!< DCMI global interrupt                                             */
+  CRYP_IRQn                   = 79,     /*!< CRYP crypto global interrupt                                      */
+  HASH_RNG_IRQn               = 80,     /*!< Hash and Rng global interrupt                                     */
+  FPU_IRQn                    = 81      /*!< FPU global interrupt                                              */
+  };
 
 
 #endif


### PR DESCRIPTION
GPIO should still be configured as input to setup pullup.
Interrupt handler has to be defined separately by user.

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>