### PR TITLE
toolchains: compiler-flags: Build with stdlib

### DIFF
--- a/toolchains/compiler-flags.cmake
+++ b/toolchains/compiler-flags.cmake
@@ -1,8 +1,8 @@
 # Compiler flags used for C and ASM files
-set(CORE_FLAGS "-mcpu=cortex-m4 -mthumb -nostdlib")
+set(CORE_FLAGS "-mcpu=cortex-m4 -mthumb -nostartfiles")
 
 # Debug flag. Also dont use stdlib
-set(DEBUG_FLAGS "${CORE_FLAGS} -g -nostdlib -O0")
+set(DEBUG_FLAGS "${CORE_FLAGS} -g -O0 -nostartfiles")
 
 # Hardware float support
 set(CORE_FLAGS "${CORE_FLAGS} -mfloat-abi=hard -mfpu=fpv4-sp-d16 -ffast-math")


### PR DESCRIPTION
Use workaround for stdlib to work with current linker script.

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>