### PR TITLE
drivers: gpio: Add alternate function as gpio type

### DIFF
--- a/src/drivers/include/gpio.h
+++ b/src/drivers/include/gpio.h
@@ -50,17 +50,26 @@ enum gpio_port {
 	PI
 };
 
+enum gpio_af {
+	SYSTEM = 0,
+	SPI1 = 5,
+	SPI2 = 5,
+	SPI3 = 6
+};
+
 /* use to init gpio and prefill gpio struct */
 struct gpio gpio_create(uint32_t port, uint32_t pin);
 int gpio_configure_output(struct gpio *gpio, enum gpio_otype otype);
 int gpio_configure_input(struct gpio *gpio, enum gpio_ptype ptype);
 /* NOTE: IRQ handler has to be defined separately! */
 int gpio_configure_interrupt(struct gpio *gpio, enum gpio_int_event event);
+int gpio_configure_af(struct gpio *gpio, enum gpio_otype otype, enum gpio_ptype ptype,
+		      enum gpio_af af);
 
 /* gpio operations */
 struct gpio_ops {
 	int (*configure)(struct gpio *gpio, enum gpio_mode mode,
-			 enum gpio_otype otype, enum gpio_ptype ptype);
+			 enum gpio_otype otype, enum gpio_ptype ptype, enum gpio_af af);
 	int (*write_val)(struct gpio *gpio, enum gpio_state val);
 	int (*read_val)(struct gpio *gpio);
 };
@@ -71,6 +80,7 @@ struct gpio_data {
 	enum gpio_mode mode;
 	enum gpio_otype otype;
 	enum gpio_ptype ptype;
+	enum gpio_af af;
 };
 
 struct gpio {


### PR DESCRIPTION
Alternate functions describe speciffic behavior of gpio pins. This may describe various peripherial devices requiring gpio input/output.

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>