### PR TITLE
workflows: cpp-check: Add cppcheck to run on pr to main

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,17 @@
+name: CppChech
+run-name: CppChech ${{ github.run_number }}
+on:
+  pull_request:
+    branches:
+    - main
+jobs:
+  Cpp-Check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: install rperequisites
+        run: sudo apt-get install -y cppcheck
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Run CppCheck
+        run: cppcheck ./src/
+        shell: bash


### PR DESCRIPTION
Run cppcheck for static code analysis. Currently gcc also prints out some analysis report on compile

Signed-off-by: Krzysztof Frydryk <frydryk.krzysztof@gmail.com>